### PR TITLE
"date" in request can differ from "date" in authentication hash

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -22,6 +22,7 @@ local function generateAuthHeaders(awsVerb, awsId, awsKey, awsToken, md5, acl, t
                          destination)
    --print(StringToSign)
    headers, err = hm:generate_headers("AWS", id, "sha1", StringToSign)
+   headers.date = date
    return headers, err
 end
 


### PR DESCRIPTION
hm::generate_header will insert a Date header with a timestamp of the moment it was called. In rare cases, StringToSign might be constructed the second before, which will lead to a mismatch between the StringToSign date and the one included in the HTTP request.

Fixed by overwriting the one returned by generate_header, with the one used to construct StringToSign
